### PR TITLE
fix #6 catbank使用時、バンク境界をまたがった直後のアドレスが不正になっていたのを修正

### DIFF
--- a/Assembler/Assembler/NesAssembler.cs
+++ b/Assembler/Assembler/NesAssembler.cs
@@ -245,7 +245,7 @@ namespace NesAsmSharp.Assembler
                 while (inPr.ReadLine() != -1)
                 {
                     asmPr.Assemble();
-                    if (ctx.LocCnt > 0x2000)
+                    if (ctx.LocCnt >= 0x2000)
                     {
                         if (ctx.ProcPtr == null)
                         {


### PR DESCRIPTION
catbank使用時、バンク境界をまたがった直後のアドレスが不正になっていたのを修正