### PR TITLE
fix #9 バンク境界ギリギリに.dbで値を置こうとするとBank overflowエラーとなる問題の修正

### DIFF
--- a/Assembler/Assembler/NesAssembler.cs
+++ b/Assembler/Assembler/NesAssembler.cs
@@ -259,6 +259,10 @@ namespace NesAsmSharp.Assembler
                                 ctx.LocCnt = newLocCnt;
                                 continue;
                             }
+                            else if (ctx.LocCnt == 0x2000)
+                            {
+                                continue;
+                            }
                             else
                             {
                                 outPr.FatalError("Bank overflow, offset > $1FFF!");


### PR DESCRIPTION
バンク境界ギリギリに.dbで値を置こうとするとBank overflowエラーとなる問題の修正